### PR TITLE
Updated to save scrape jobs to database.

### DIFF
--- a/src/database/scrape-attempt.js
+++ b/src/database/scrape-attempt.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
+// scrape attempt on a specific scrape item
 let scrapeAttempt = new Schema({
   scrapeItemId: Schema.ObjectId,
   scrapeStartDate: Date,

--- a/src/database/scrape-item.js
+++ b/src/database/scrape-item.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
+// a scrape item is a url page that can contain multiple pdfs
 let scrapeItem = new Schema({
   type: String, // html or pdf
   state: String, // state CA, NV

--- a/src/database/scrape-job.js
+++ b/src/database/scrape-job.js
@@ -1,10 +1,12 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
+// a scrape job is saved after all scrape attempts (based on each scrape item) have completed
+// mark as failed if all scrape attempts do not complete
 let scrapeJob = new Schema({
-  runDate: Date,
-  status: String, // succ/fail
-  errorInfo: String,
+  startDate: Date,
+  endDate: Date,
+  status: String, // success or fail
 });
 
 module.exports = mongoose.model('ScrapeJob', scrapeJob);

--- a/src/database/user.js
+++ b/src/database/user.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
+// a user is for email notification
 let user = new Schema({
   email: String,
   name: String,

--- a/src/main.js
+++ b/src/main.js
@@ -3,8 +3,8 @@ const api = require('./api');
 const port = process.env.PORT || 3000;
 api.listen(port, () => {
   console.log(`Server started on ${port}`);
-});
 
-const Scheduler = require('./scheduler');
-const s = new Scheduler(60 * 60 * 1000);
-s.start();
+  const Scheduler = require('./scheduler');
+  const s = new Scheduler(60 * 60 * 1000);
+  s.start();
+});

--- a/src/scheduler/index.js
+++ b/src/scheduler/index.js
@@ -1,5 +1,12 @@
 const { notify } = require('../notifier');
-const { loadItemsToScrape, getUsersToNotify } = require('../database');
+const {
+  clearScrapeJobs,
+  getScrapeJobs,
+  loadItemsToScrape,
+  findItemToScrape,
+  createScrapeJob,
+  updateScrapeJob,
+} = require('../database');
 const { evaluate } = require('../scraper');
 
 class Scheduler {
@@ -9,26 +16,61 @@ class Scheduler {
   }
 
   async run() {
-    const now = Date.now();
-    console.log(`Beginning run: ${new Date(now).toISOString()}`);
+    // DEBUG: uncomment next line to clear all scrape jobs
+    //const result = await clearScrapeJobs();
+
+    // DEBUG: view the scrape jobs
+    //const scrapeJobs = await getScrapeJobs();
+    //console.log('Scrape jobs: ', scrapeJobs);
+
+    // record the start of the scrape job
+    const scrapeJobsStartDate = Date.now();
+    console.log(`\n********** Started scrape job at ${new Date(scrapeJobsStartDate).toISOString()} **********\n`);
+    let currentScrapeJob = await createScrapeJob(scrapeJobsStartDate);
+
+    console.log('\n********** Loading scrape items from database **********\n');
     const items = await loadItemsToScrape();
-    console.log(items);
 
-    const users = await getUsersToNotify();
-    //console.log(users);
+    // DEBUG: find one item to scrape for testing
+    //const items = [ await findItemToScrape({ state: 'CA' }) ];
+    //console.log(items);
 
+    const totalItems = items.length;
+    console.log('\n********** Loaded ' + totalItems + ' scrape items **********\n');
+
+    console.log('\n********** Start evaluating scrape items **********\n');
     const changes = [];
-    for (let i = 0; i < items.length; i++) {
+    for (let i = 0; i < totalItems; i++) {
+      console.log('\n********** Evaluating scrape item ' + (i + 1) + ' of ' + totalItems + ' **********\n');
+      // TODO: create scrape attempt
       const change = await evaluate(items[i]);
+      // TODO: update scrape attempt and scrape items
       if (change) {
+        console.log('\n********** Scrape item ' + (i + 1) + ' changed **********\n');
         changes.push(change);
       }
     }
+    console.log('\n********** Done evaluating scrape items **********\n');
 
-    //notify(changes);
+    // update scrape job to indicate it completed
+    const scrapeJobsEndDate = Date.now();
+    await updateScrapeJob(currentScrapeJob._id, scrapeJobsEndDate);
+
+    console.log(`\n********** Completed scrape job at ${new Date(scrapeJobsEndDate).toISOString()} **********\n`);
+    const scrapeJobTimeSec = parseInt((scrapeJobsEndDate - scrapeJobsStartDate) / 1000);
+    //console.log('scrapeJobTimeSec', scrapeJobTimeSec);
+    const scrapeJobTimeMin = parseInt(scrapeJobTimeSec / 60);
+    console.log(`Scrape job compeleted in ${scrapeJobTimeMin} min ${scrapeJobTimeSec % 60} sec`);
+
+    // send changes to notifier
+    //notify(changes).then(function (data) {
+    // exit for now
+    //process.exit();
+    //});
   }
 
   start() {
+    // temporarily disable interval
     //this.interval = setInterval(this.run, this.periodMs);
     this.run();
   }

--- a/src/scraper/pdf.js
+++ b/src/scraper/pdf.js
@@ -10,23 +10,18 @@ async function hashPdf(url) {
   let options = {
     version: 'v2.0.550',
   };
-  axios
-    .get(url, { responseType: 'arraybuffer' })
-    .then(function (data) {
-      pdfParser(data, options)
-        .then(function (pdf) {
-          const hash = crypto.createHash('md5').update(pdf.text).digest('hex');
-          return { url, hash, error: '' };
-        })
-        .catch(function (error) {
-          console.log('pdfParser error: ', error.message);
-          return { url, hash: '', error: error.message };
-        });
-    })
-    .catch(function (error) {
-      console.log('axios error: ', error.message);
-      return { url, hash: '', error: error.message };
-    });
+  try {
+    const data = await axios.get(url, { responseType: 'arraybuffer' });
+    try {
+      const pdf = await pdfParser(data, options);
+      const hash = crypto.createHash('md5').update(pdf.text).digest('hex');
+      return { url, hash, error: null };
+    } catch (error) {
+      return { url, hash: null, error: `pdf-parse error: ${error.message}` };
+    }
+  } catch (error) {
+    return { url, hash: null, error: `axios error: ${error.message}` };
+  }
 }
 
 module.exports = {

--- a/src/scraper/text.js
+++ b/src/scraper/text.js
@@ -10,7 +10,7 @@ function diffText(oldText, newText) {
   const newCleaned = cleanText(newText);
 
   const chunks = diff.diffSentences(oldCleaned, newCleaned);
-  // console.log(chunks);
+  //console.log(chunks);
 
   let lastChunk = { value: '' };
   const diffs = [];


### PR DESCRIPTION
Some clean up and lots of console logs here but now adds `ScrapeJob` to database and updates when a full run of all `ScrapeItems` have completed.

- Updated PDF scraper from promise `then/catch` to `async/await` to avoid nesting and allow for better error handling.
- Verified that ScrapeItems will get processed in order so a complete ScrapeJob of 102 ScrapeItem takes about 10 minutes.